### PR TITLE
Web5028 decouple auth

### DIFF
--- a/CHANGELOG.md 
+++ b/CHANGELOG.md 
@@ -1,5 +1,5 @@
 ## **1.1.0**
-- [**WEB-5028**](https://hxshortbreaks.atlassian.net/browse/WEB-5028) Bump hapijs version and proxy auth.artfiacts when "including".
+- [**WEB-5028**](https://hxshortbreaks.atlassian.net/browse/WEB-5028) Bump hapijs version to 8.6.1 and proxy auth.artfiacts when "including".
 ## **1.0.0**
 - [**WEB-4809**](https://hxshortbreaks.atlassian.net/browse/WEB-4809) Swapping build agent to Shippable.
 ## **0.1.1**

--- a/CHANGELOG.md 
+++ b/CHANGELOG.md 
@@ -1,5 +1,7 @@
+## **1.1.0**
+- [**WEB-5028**](https://hxshortbreaks.atlassian.net/browse/WEB-5028) Bump hapijs version and proxy auth.artfiacts when "including".
 ## **1.0.0**
-- [**WEB-4809**](https://hxshortbreaks.atlassian.net/browse/WEB-4809) - Swapping build agent to Shippable.
+- [**WEB-4809**](https://hxshortbreaks.atlassian.net/browse/WEB-4809) Swapping build agent to Shippable.
 ## **0.1.1**
 - [**WEB-4542**](https://hxshortbreaks.atlassian.net/browse/WEB-4542) Upgrade coding styles to current level.
 ## **0.1.0**

--- a/lib/pluginJsonapi.js
+++ b/lib/pluginJsonapi.js
@@ -70,6 +70,7 @@ function pluginJsonapi( server, options, next ) {
 			request.server.inject( {
 				url: subResourceUrl,
 				credentials: request.auth.credentials,
+				artifacts: request.auth.artifacts,
 				headers: {
 					host: 'theworks-production.t-bob.co.uk'
 				}

--- a/lib/pluginJsonapi.js
+++ b/lib/pluginJsonapi.js
@@ -65,7 +65,7 @@ function pluginJsonapi( server, options, next ) {
 			var proxyDeferred = Q.defer();
 			proxyDeferreds.push( proxyDeferred.promise );
 			// Where will we find this resource?
-			// if a context is available, proxy it to sub resources
+			// if a `context` is available, proxy it to sub resources
 			var subResourceUrl = _buildHref( type, ids, request.url.query.context );
 			request.server.inject( {
 				url: subResourceUrl,

--- a/lib/pluginJsonapi.js
+++ b/lib/pluginJsonapi.js
@@ -31,7 +31,6 @@ function pluginJsonapi( server, options, next ) {
 	* @param {Array} context
 	*/
 	function _buildHref( type, ids, context ) {
-
 		ids =  _.isArray( ids ) ? ids.join( ',' ) : ids;
 
 		var queryString = '';
@@ -66,6 +65,7 @@ function pluginJsonapi( server, options, next ) {
 			var proxyDeferred = Q.defer();
 			proxyDeferreds.push( proxyDeferred.promise );
 			// Where will we find this resource?
+			// if a context is available, proxy it to sub resources
 			var subResourceUrl = _buildHref( type, ids, request.url.query.context );
 			request.server.inject( {
 				url: subResourceUrl,
@@ -82,7 +82,6 @@ function pluginJsonapi( server, options, next ) {
 					// Return an empty array, we can send out as much content as we have, except this one...
 					proxyDeferred.resolve( {} );
 				}
-
 			} );
 		} );
 
@@ -148,7 +147,7 @@ function pluginJsonapi( server, options, next ) {
 				// Get the current resource from the result
 				var resources = result[request.route.settings.bind.resourceName];
 				if( resources ) {
-					// Ensure it's an array.
+					// Controllers should return an array of resources but double check here
 					var resourceArray = ( _.isArray( resources ) ) ? resources : [resources];
 					// Before we start doing anything intensive, scratch out the includes
 					var includes = [];
@@ -157,7 +156,6 @@ function pluginJsonapi( server, options, next ) {
 					}
 					// Loop the resources and pad out any required hrefs
 					_.each( resourceArray, function( resource ) {
-
 						// build a href for the resource if there's an id property
 						if( resource.id ) {
 							resource.href = _buildHref( request.route.settings.bind.resourceName, resource.id );
@@ -169,6 +167,8 @@ function pluginJsonapi( server, options, next ) {
 								// Need both type and ids to do anything meaningful here
 								if( value.type && _.size( value.ids ) ) {
 									// Build the relevant href
+									// note we don't pass in any context properties to links as they
+									// are as the name suggests, contextual
 									value.href = _buildHref( value.type, value.ids );
 								}
 							} );

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt": "0.4.5",
     "grunt-contrib-jshint": "0.11.0",
     "grunt-jscs": "1.5.0",
-    "hapi": "8.2.0",
+    "hapi": "8.6.1",
     "istanbul": "0.3.7",
     "joi": "6.1.2",
     "make-up": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-jsonapi",
   "description": "A hapi plugin for a jsonapi style output according to our 'house rules'",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://github.com/holidayextras/plugin-jsonapi",
   "author": {
     "name": "Shortbreaks",

--- a/test/fixtures/routes.js
+++ b/test/fixtures/routes.js
@@ -34,6 +34,25 @@ module.exports = [
 			} );
 		}
 	},
+
+	{
+		method: 'GET',
+		path: '/singleResourceObject',
+		config: {
+			bind: {
+				resourceName: 'test'
+			}
+		},
+		handler: function( request, reply ) {
+			reply( {
+				test: {
+					id: '123456789',
+					foo: 'bar'
+				}
+			} );
+		}
+	},
+
 	{
 		method: 'GET',
 		path: '/addHrefToResource',
@@ -198,6 +217,67 @@ module.exports = [
 			reply( {
 				secondaryResource: [ {
 					foo: 'bar'
+				} ]
+			} );
+		}
+	},
+	{
+		method: 'GET',
+		path: '/primaryContextResource',
+		config: {
+			validate: {
+				options: {
+					allowUnknown: true
+				},
+				query: {
+					include: Joi.string().optional()
+				}
+			},
+			bind: {
+				resourceName: 'primaryContextResource'
+			}
+		},
+		handler: function( request, reply ) {
+			// setup the include and context proxy
+			request.data = {
+				query: {
+					include: request.query.include,
+					context: request.query.context
+				}
+			};
+			reply( {
+				primaryContextResource: [ {
+					foo: 'bar',
+					links: {
+						secondaryContextResource: {
+							ids: [1],
+							type: 'secondaryContextResource'
+						}
+					}
+				} ]
+			} );
+		}
+	},
+	{
+		method: 'GET',
+		path: '/secondaryContextResource/{id}',
+		config: {
+			validate: {
+				options: {
+					allowUnknown: true
+				}
+			},
+			bind: {
+				resourceName: 'secondaryContextResource'
+			}
+		},
+		handler: function( request, reply ) {
+			// note we're conditionally adding the a boolean to flag whether the
+			// additionalContextInfo context was proxied successfully
+			reply( {
+				secondaryContextResource: [ {
+					foo: 'bar',
+					additionalContextInfo: request.query.context.secondaryContextResource.additionalContextInfo ? true : false
 				} ]
 			} );
 		}

--- a/test/pluginJsonapiTest.js
+++ b/test/pluginJsonapiTest.js
@@ -254,6 +254,9 @@ describe( 'pluginJsonapi', function() {
 			} );
 		} );
 
+
+		// TODO: write a test to ensure auth.artifacts are proxied to includes
+
 	} );
 
 } );

--- a/test/pluginJsonapiTest.js
+++ b/test/pluginJsonapiTest.js
@@ -101,6 +101,19 @@ describe( 'pluginJsonapi', function() {
 			} );
 		} );
 
+		it( 'should handle a single object resource', function( done ) {
+			server.inject( '/singleResourceObject', function( reply ) {
+				reply.result.should.deep.equal( {
+					test: {
+						id: '123456789',
+						foo: 'bar',
+						href: '/test/123456789'
+					}
+				} );
+				done();
+			} );
+		} );
+
 	} );
 
 	describe( 'hrefs', function() {
@@ -197,7 +210,7 @@ describe( 'pluginJsonapi', function() {
 
 	} );
 
-	describe( 'include', function() {
+	describe( 'when "including"', function() {
 
 		it( 'should fetch a single secondary resource and add it to the primary resource linked data', function( done ) {
 			server.inject( '/primaryResource?include=secondaryResource', function( reply ) {
@@ -217,6 +230,32 @@ describe( 'pluginJsonapi', function() {
 					linked: {
 						secondaryResource: [ {
 							foo: 'bar'
+						} ]
+					}
+				} );
+				done();
+			} );
+		} );
+
+		it( 'should fetch a single secondary resource with context info and add it to the primary resource linked data', function( done ) {
+			server.inject( '/primaryContextResource?include=secondaryContextResource&context[secondaryContextResource][additionalContextInfo]=true', function( reply ) {
+				reply.result.should.deep.equal( {
+					primaryContextResource: [
+						{
+							foo: 'bar',
+							links: {
+								secondaryContextResource: {
+									ids: [1],
+									type: 'secondaryContextResource',
+									href: '/secondaryContextResource/1'
+								}
+							}
+						}
+					],
+					linked: {
+						secondaryContextResource: [ {
+							foo: 'bar',
+							additionalContextInfo: true
 						} ]
 					}
 				} );
@@ -253,9 +292,6 @@ describe( 'pluginJsonapi', function() {
 				done();
 			} );
 		} );
-
-
-		// TODO: write a test to ensure auth.artifacts are proxied to includes
 
 	} );
 


### PR DESCRIPTION
#### What are the links to relevant tickets?
https://hxshortbreaks.atlassian.net/browse/WEB-5028

#### What does this PR do?
Updates Hapijs to allow the ability to proxy `auth.artifacts` on to any "includes"

Anticipated version, 1.1.0

#### What functional/unit tests does this PR have?
The artifacts proxy is impossible to test as I don't have access to that information after the proxy is performed.  I have extended the test coverage to cover the context case and the single object resource case.

#### How should a developer review this?
Visual code review and pull down and run the tests.

#### Any background context you want to provide?
There's another PR for The Works to consuming this change to allow the decoupling of the auth from consumers.

#### Screenshots (if appropriate)
Old
![screen shot 2015-06-15 at 13 40 41](https://cloud.githubusercontent.com/assets/738971/8160092/a684e6d0-1364-11e5-98ec-51289a4f9e4c.png)

New
![screen shot 2015-06-15 at 13 39 52](https://cloud.githubusercontent.com/assets/738971/8160095/afd53af0-1364-11e5-941c-66a51566d2f0.png)

---
#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've checked there is appropriate unit test coverage.
- [x] I've updated documentation with any changes to procedures.
- [x] I've tested this cross browser for any visual changes.
- [x] I've checked this work against the requirements of the Jira.
- [x] I am ready for this to be code reviewed, merged and tested.

#### Reviewer 1 @t1gr0u
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve witnessed the tests running successfully.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!

#### Reviewer 2 @notABluesSinger
- [x] I agree with the assumptions made in the quality checklist.
- [ ] I’ve witnessed the work behaving as expected.
- [x] I’ve witnessed the tests running successfully.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked for coding anti-patterns.
- [x] I've checked this work against the requirements of the Jira.
- [x] I don’t believe this work introduces unnecessary technical debt.
- [x] +1 from me!