### PR TITLE
dont include linked resources already present in the response

### DIFF
--- a/lib/pluginJsonapi.js
+++ b/lib/pluginJsonapi.js
@@ -61,6 +61,7 @@ pluginJsonApi.alsoMakeItSo = function alsoMakeItSo (request, reply) {
     var stateObject = {
       request: request,
       resources: resources,
+      linked: result.linked,
       proxyableKeys: proxyableKeys
     }
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -161,14 +161,16 @@ utilities.getSubResources = function getSubResources (stateObject) {
   }
 
   stateObject.subResourceRequests = {}
-
   // Loop the resources and pad out any required hrefs
   _.forEach(resourceArray, function (resource) {
     // If there's no links then there's no actions to take
     if (resource.links) {
-      // Loop all the includes and pad out our subResourceRequest array
+      // Loop all the includes and if required pad out our subResourceRequest array
       _.forEach(stateObject.includes, function (include) {
-        // If we have links to the requested include, chalk it up
+        if (stateObject.linked && stateObject.linked[include]) {
+          // We already have these resources
+          return
+        }
         if (resource.links && resource.links[include]) {
           utilities._addSubResourceRequest(stateObject.subResourceRequests, resource.links[include])
         }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -171,7 +171,7 @@ utilities.getSubResources = function getSubResources (stateObject) {
           // We already have these resources
           return
         }
-        if (resource.links && resource.links[include]) {
+        if (resource.links[include]) {
           utilities._addSubResourceRequest(stateObject.subResourceRequests, resource.links[include])
         }
       })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-jsonapi",
   "description": "A hapi plugin for a jsonapi style output according to our 'house rules'",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "homepage": "https://github.com/holidayextras/plugin-jsonapi",
   "author": {
     "name": "Shortbreaks",

--- a/test/lib/utilitiesTest.js
+++ b/test/lib/utilitiesTest.js
@@ -113,6 +113,31 @@ describe('utilities', function () {
 
       return expect(utilities.getSubResources(stateObject)).to.eventually.deep.equal(stateObject)
     })
+
+    it('should not attach any already linked sub resources', function () {
+      var stateObject = {
+        resources: [
+          {
+            id: 'ID',
+            links: {
+              LINK1: {
+                ids: ['LINK_ID1'],
+                type: 'LINK1'
+              }
+            }
+          }
+        ],
+        includes: ['LINK1'],
+        linked: {
+          LINK1: []
+        }
+      }
+
+      var expected = _.cloneDeep(stateObject)
+      expected.subResourceRequests = {}
+
+      return expect(utilities.getSubResources(stateObject)).to.eventually.deep.equal(expected)
+    })
   })
 
   describe('#resolveLinkedData', function () {
@@ -356,7 +381,6 @@ describe('utilities', function () {
       expect(links).to.be.deep.equal(expected)
     })
   })
-  // _requestSubResource
 
   describe('#collectProxyableValues', function () {
     var stateObject = {

--- a/test/lib/utilitiesTest.js
+++ b/test/lib/utilitiesTest.js
@@ -138,6 +138,38 @@ describe('utilities', function () {
 
       return expect(utilities.getSubResources(stateObject)).to.eventually.deep.equal(expected)
     })
+
+    it('should not attach any already linked sub resources, but still add unlinked ones', function () {
+      var stateObject = {
+        resources: [
+          {
+            id: 'ID',
+            links: {
+              LINK1: {
+                ids: ['LINK_ID1'],
+                type: 'LINK1'
+              },
+              LINK2: {
+                ids: ['LINK_ID2'],
+                type: 'LINK2'
+              }
+            }
+          }
+        ],
+        includes: ['LINK1', 'LINK2'],
+        linked: {
+          LINK1: []
+        }
+      }
+
+      var expected = _.cloneDeep(stateObject)
+      expected.subResourceRequests = {
+        LINK2: {
+          ids: ['LINK_ID2']
+        }
+      }
+      return expect(utilities.getSubResources(stateObject)).to.eventually.deep.equal(expected)
+    })
   })
 
   describe('#resolveLinkedData', function () {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
https://hxshortbreaks.atlassian.net/browse/FP-1042
Some The Works endpoints now create their own `linked` resources (see https://github.com/holidayextras/the-works/pull/590 which will consume this work once merged) removing the need for plugin-jsonapi to request them. Plugin-jsonapi now handles this by checking for the presence of linked includes before adding them onto the request array.

This is a performance/optimisation piece.

#### What tests does this PR have?
One additional test to cover the additional usecase of the `getSubResources` function
#### How can this be tested?
On it's own, not so much. Pull down https://github.com/holidayextras/the-works/pull/590 and run a GET /packageRates request with an `include` of `ticketRates,roomRates,hotelProducts`. You will then see plugin-jsonapi only request the `hotelProducts` as the packageRates endpoint will return the ticketRates and roomRates resources itself.

#### Any tech debt?
None

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?
![]()

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
