### PR TITLE
Added room rates to proxyableKeys

### DIFF
--- a/lib/pluginJsonapi.js
+++ b/lib/pluginJsonapi.js
@@ -20,7 +20,8 @@ var ignoreStatusCodes = [
 var proxyableKeys = [
   'contentVersion',
   'lang',
-  'ticketRates'
+  'ticketRates',
+  'roomRates'
 ]
 
 var pluginJsonApi = module.exports = {}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-jsonapi",
   "description": "A hapi plugin for a jsonapi style output according to our 'house rules'",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "homepage": "https://github.com/holidayextras/plugin-jsonapi",
   "author": {
     "name": "Shortbreaks",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "hapi-qs": "git+ssh://git@github.com/soxhub/hapi-qs.git#master",
     "istanbul": "^1.1.0-alpha.1",
     "joi": "10.4.1",
-    "mocha": "^3.0.2",
+    "mocha": "^5.2.0",
     "sinon": "^1.17.4",
     "sinon-as-promised": "^4.0.2",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
Jira: https://hxshortbreaks.atlassian.net/browse/FP-11285

#### What does this PR do? (please provide any background)
This PR adds roomRates to be available in revolver so we can check for length of stay when displaying messages.

#### What tests does this PR have?
None

#### How can this be tested?
I can show you locally.

#### Any tech debt?

#### Screenshots / Screencast
![image](https://user-images.githubusercontent.com/29861480/47780911-53271000-dcf4-11e8-98b0-07ea09216b8d.png)

#### What gif best describes how you feel about this work?
![]()

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---