### PR TITLE
Allow referrer header to be passed on in sub resource requests

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -194,7 +194,7 @@ utilities.getSubResources = function getSubResources (stateObject) {
   return Q.resolve(stateObject)
 }
 
-// request the sub resources
+// request the sub resources.
 utilities._requestSubResource = async function _requestSubResource (request, info, type, proxiedValues) {
   var hrefParameters = {
     type: type,
@@ -220,13 +220,18 @@ utilities._requestSubResource = async function _requestSubResource (request, inf
     headerHost += ':' + request.auth.artifacts.port
   }
 
+  var headers = {
+    host: headerHost
+  }
+  if (request.headers && request.headers.referrer) {
+    headers.referrer = request.headers.referrer
+  }
+
   const response = await request.server.inject({
     url: subResourceUrl,
     credentials: request.auth.credentials,
     artifacts: request.auth.artifacts,
-    headers: {
-      host: headerHost
-    }
+    headers: headers
   })
   // Append the result to our linked property if it responded without an error
   if (!response.result.error) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-jsonapi",
   "description": "A hapi plugin for a jsonapi style output according to our 'house rules'",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "homepage": "https://github.com/holidayextras/plugin-jsonapi",
   "author": {
     "name": "Shortbreaks",


### PR DESCRIPTION
Where we allow multiple referrers on our platform, we need to have it set as `headers.referrer` for the works to allow subresource requests to be made.
This would allow that to happen.